### PR TITLE
Fix log edit form pre-filling today's date instead of entry date

### DIFF
--- a/src/lib/components/LogForm.svelte
+++ b/src/lib/components/LogForm.svelte
@@ -47,7 +47,7 @@
 
 		hour = initialHourStr;
 		minute = initialMinuteStr;
-		date = formatDateForInput(currentDateTime);
+		date = formatDateForInput(initialData.timestamp);
 	}
 
 	function* range(start: number, end: number): Generator<number> {


### PR DESCRIPTION
## Summary

- Fixes `LogForm.svelte` pre-filling the date field with today's date when editing an existing log entry
- Hour and minute were already correctly read from `initialData.timestamp`; the date was not

## Change

```ts
// before
date = formatDateForInput(currentDateTime);

// after
date = formatDateForInput(initialData.timestamp);
```

## Test plan

- [ ] Open an existing log entry for editing — date field should show the entry's original date, not today
- [ ] Creating a new log entry still defaults to today's date (unaffected path)

Closes #3