### PR TITLE
Remove duplicate entry_tags table in favour of log_tag

### DIFF
--- a/drizzle/0005_drop_entry_tags_table.sql
+++ b/drizzle/0005_drop_entry_tags_table.sql
@@ -1,0 +1,1 @@
+DROP TABLE "entry_tags" CASCADE;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,306 @@
+{
+  "id": "1a3ff1d9-2cc1-4855-a5e2-6170672c6eec",
+  "prevId": "7fc431a7-d59e-4124-be8b-7d228736e492",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.log_entries": {
+      "name": "log_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unix": {
+          "name": "unix",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "extract(epoch from now())"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "4"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "log_entries_type_id_log_types_id_fk": {
+          "name": "log_entries_type_id_log_types_id_fk",
+          "tableFrom": "log_entries",
+          "tableTo": "log_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.log_tag": {
+      "name": "log_tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "log_tag_entry_id_log_entries_id_fk": {
+          "name": "log_tag_entry_id_log_entries_id_fk",
+          "tableFrom": "log_tag",
+          "tableTo": "log_entries",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "log_tag_tag_id_tags_id_fk": {
+          "name": "log_tag_tag_id_tags_id_fk",
+          "tableFrom": "log_tag",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.log_types": {
+      "name": "log_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blue-100'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1757073503612,
       "tag": "0004_low_spot",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1780158154567,
+      "tag": "0005_drop_entry_tags_table",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, integer, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { pgTable, integer, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 
 export const user = pgTable('user', {
 	id: uuid('id').defaultRandom().primaryKey(),
@@ -20,14 +20,12 @@ export type Session = typeof session.$inferSelect;
 export type User = typeof user.$inferSelect;
 
 // 👇 Import table definitions
-import { entryTags } from './schema/entry_tags';
 import { logEntries } from './schema/log_entries';
 import { logTypes } from './schema/log_types';
 import { tags } from './schema/tags';
 import { logTag} from './schema/log_tag';
 
 // 👇 Export inferred types
-export type EntryTag = typeof entryTags.$inferSelect;
 export type LogEntry = typeof logEntries.$inferSelect;
 export type LogType = typeof logTypes.$inferSelect;
 export type Tag = typeof tags.$inferSelect;
@@ -40,7 +38,6 @@ export type NewLogType = typeof logTypes.$inferInsert;
 
 // 👇 Optionally export the tables too
 export {
-    entryTags,
     logEntries,
     logTypes,
     tags,

--- a/src/lib/server/db/schema/entry_tags.ts
+++ b/src/lib/server/db/schema/entry_tags.ts
@@ -1,8 +1,0 @@
-import { pgTable, uuid } from 'drizzle-orm/pg-core';
-import { logEntries } from './log_entries';
-import { tags } from './tags';
-
-export const entryTags = pgTable('entry_tags', {
-    entryId: uuid('entry_id').references(() => logEntries.id).notNull(),
-    tagId: uuid('tag_id').references(() => tags.id).notNull(),
-});


### PR DESCRIPTION
## Summary

- Removes `entry_tags`, a table created in the initial migration that was never queried
- `log_tag` covers the identical relationship (log entries ↔ tags) and is the table actually used in the application
- Removes `src/lib/server/db/schema/entry_tags.ts`
- Removes `EntryTag` type and `entryTags` export from `schema.ts`
- Removes unused `serial` import from `schema.ts`
- Adds Drizzle migration `0005_drop_entry_tags_table.sql` — `DROP TABLE "entry_tags" CASCADE`

## Test plan

- [ ] Run `npm run db:migrate` — migration applies cleanly
- [ ] Application starts without errors
- [ ] Tag selection on log entries still works (reads/writes via `log_tag`)
- [ ] No TypeScript errors (`tsc --noEmit`)

Closes #4