### PR TITLE
Replace N+1 tag inserts with a single batch insert

### DIFF
--- a/src/lib/server/db/utils/saveTags.ts
+++ b/src/lib/server/db/utils/saveTags.ts
@@ -9,22 +9,19 @@ const logTagSchema = z.object({
 });
 
 export async function saveTagsForEntry(entryId: string, tagIds: FormDataEntryValue[]) {
-    // Clear existing tags
     await db.delete(logTag).where(eq(logTag.entryId, entryId));
 
-    // Insert new tags
-    for (const tagId of tagIds) {
-        const tagEntry = {
-            entryId,
-            tagId: tagId.toString()
-        };
+    const validEntries = tagIds
+        .map(tagId => ({ entryId, tagId: tagId.toString() }))
+        .filter(entry => {
+            const result = logTagSchema.safeParse(entry);
+            if (!result.success) {
+                console.warn('Invalid tag entry skipped:', entry);
+            }
+            return result.success;
+        });
 
-        const validation = logTagSchema.safeParse(tagEntry);
-        if (!validation.success) {
-            console.warn('Invalid tag entry skipped:', tagEntry);
-            continue;
-        }
-
-        await db.insert(logTag).values(tagEntry);
+    if (validEntries.length > 0) {
+        await db.insert(logTag).values(validEntries);
     }
 }


### PR DESCRIPTION
## Summary

`saveTagsForEntry` previously inserted one tag per database round-trip inside a loop. This replaces that with a single `INSERT` statement for all valid entries.

## Change

```ts
// before: N inserts
for (const tagId of tagIds) {
    await db.insert(logTag).values(tagEntry);
}

// after: 1 insert
if (validEntries.length > 0) {
    await db.insert(logTag).values(validEntries);
}
```

## Test plan

- [ ] Save a log entry with multiple tags — all tags persist correctly
- [ ] Save a log entry with no tags — no insert is attempted, existing tags are cleared
- [ ] Invalid tag IDs are skipped with a console warning

Closes #5