### PR TITLE
Make date utility functions immutable

### DIFF
--- a/src/lib/utils/date.test.ts
+++ b/src/lib/utils/date.test.ts
@@ -1,20 +1,16 @@
-// adjustForLocalTime.test.ts
 import { describe, it, expect } from 'vitest';
 import { adjustForLocalTime } from './date';
 
 describe('adjustForLocalTime', () => {
-    it('should adjust a UTC timestamp to local time', () => {
-        const utcDate = new Date(Date.UTC(2023, 0, 1, 12, 0, 0)); // 12:00 UTC
-    
-        // Before adjustment: local hour of UTC time
-        const beforeAdjustment = utcDate.getHours();
-    
-        adjustForLocalTime(utcDate);
-    
-        // After adjustment: should be offset by system timezone
+    it('should return a new Date adjusted to local time without mutating the input', () => {
+        const utcDate = new Date(Date.UTC(2023, 0, 1, 12, 0, 0));
+        const originalTime = utcDate.getTime();
+        const beforeHour = utcDate.getHours();
+
+        const result = adjustForLocalTime(utcDate);
+
         const offsetHours = -new Date().getTimezoneOffset() / 60;
-        const expectedHour = beforeAdjustment + offsetHours;
-    
-        expect(utcDate.getHours()).toBe(expectedHour);
-      });
+        expect(result.getHours()).toBe(beforeHour + offsetHours);
+        expect(utcDate.getTime()).toBe(originalTime);
+    });
 });

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -1,66 +1,41 @@
 import { TZDate } from '@date-fns/tz';
 
-/**
- * Date really sucks. Need localtime, not UTC.
- * 
- * @param timestamp 
- */
-export function adjustForLocalTime(timestamp: Date) {
-    const offsetMinutes = new Date().getTimezoneOffset(); // e.g. -120 for +2 hours
-    const offsetHours = -offsetMinutes / 60;
-
-    timestamp.setHours(timestamp.getHours() + offsetHours);
+export function adjustForLocalTime(timestamp: Date): Date {
+    const offsetMinutes = new Date().getTimezoneOffset();
+    const result = new Date(timestamp);
+    result.setHours(result.getHours() + (-offsetMinutes / 60));
+    return result;
 }
 
 export function localTimeToUTC(timestamp: Date): Date {
-    const offsetMinutes = new Date().getTimezoneOffset(); // e.g. -120 for +2 hours
-    const offsetHours = +offsetMinutes / 60;
-
-    timestamp.setHours(timestamp.getHours() + offsetHours);
-
-    return timestamp;
+    const offsetMinutes = new Date().getTimezoneOffset();
+    const result = new Date(timestamp);
+    result.setHours(result.getHours() + (offsetMinutes / 60));
+    return result;
 }
 
 export function utcToLocalTime(timestamp: Date): Date {
-    const offsetMinutes = new Date().getTimezoneOffset(); // e.g. -120 for +2 hours
-    const offsetHours = -offsetMinutes / 60;
-
-    timestamp.setHours(timestamp.getHours() + offsetHours);
-
-    return timestamp;
+    const offsetMinutes = new Date().getTimezoneOffset();
+    const result = new Date(timestamp);
+    result.setHours(result.getHours() + (-offsetMinutes / 60));
+    return result;
 }
 
-
-/**
- * Since Date really sucks, we have to do this to get the correct local time.
- * 
- * @param timestamp 
- */
-export function adjustReverseForLocalTime(timestamp: Date) {
-    const offsetMinutes = new Date().getTimezoneOffset(); // e.g. -120 for +2 hours
-    const offsetHours = +offsetMinutes / 60;
-
-    timestamp.setHours(timestamp.getHours() + offsetHours);
+export function adjustReverseForLocalTime(timestamp: Date): Date {
+    const offsetMinutes = new Date().getTimezoneOffset();
+    const result = new Date(timestamp);
+    result.setHours(result.getHours() + (offsetMinutes / 60));
+    return result;
 }
 
-/**
- * 
- * @param date 
- * @returns 
- */
 export function formatDateForInput(date: Date): string {
     const year = date.getFullYear();
     const month = String(date.getMonth() + 1).padStart(2, '0');
     const day = String(date.getDate()).padStart(2, '0');
 
-    return `${year}-${month}-${day}`; // ✅ "YYYY-MM-DD"
+    return `${year}-${month}-${day}`;
 }
 
-/**
- * 
- * @param currentDateTime 
- * @returns 
- */
 export function formatTimeForInput(currentDateTime: Date): { hour: string; minute: string } {
     const hour = String(currentDateTime.getHours()).padStart(2, '0');
     const minute = String(currentDateTime.getMinutes()).padStart(2, '0');
@@ -85,5 +60,5 @@ export function getUTCRange(date: Date) {
     return {
         startUTC: localStart,
         endUTC: localEnd,
-    }
+    };
 }

--- a/src/routes/dashboard/log/add/[slug]/+page.server.ts
+++ b/src/routes/dashboard/log/add/[slug]/+page.server.ts
@@ -7,7 +7,6 @@ import { tags } from '$lib/server/db/schema/tags';
 import { logEntries } from '$lib/server/db/schema/log_entries';
 import { z } from 'zod';
 import { eq } from 'drizzle-orm';
-import { localTimeToUTC } from '$lib/utils/date';
 import { saveTagsForEntry } from '$lib/server/db/utils/saveTags';
 
 export const load: PageServerLoad = (async ({ locals, params }) => {


### PR DESCRIPTION
## Summary

All four timezone-adjustment functions in `date.ts` previously mutated the `Date` object passed in via `setHours()`. They now return a new `Date` and leave the original untouched.

- `adjustForLocalTime` — returns new Date, no longer void
- `localTimeToUTC` — returns new Date instead of mutating and returning same reference
- `utcToLocalTime` — same
- `adjustReverseForLocalTime` — returns new Date, no longer void
- Removed unused `localTimeToUTC` import from `log/add/[slug]/+page.server.ts`

## Test plan

- [ ] `npx vitest run --project server` passes
- [ ] Log entry creation still stores the correct timestamp
- [ ] Log entry editing still displays the correct date and time

Closes #6