### PR TITLE
Handle network errors in verifyPasswordStrength

### DIFF
--- a/src/lib/server/password.ts
+++ b/src/lib/server/password.ts
@@ -21,14 +21,24 @@ export async function verifyPasswordStrength(password: string): Promise<boolean>
 	}
 	const hash = encodeHexLowerCase(sha1(new TextEncoder().encode(password)));
 	const hashPrefix = hash.slice(0, 5);
-	const response = await fetch(`https://api.pwnedpasswords.com/range/${hashPrefix}`);
-	const data = await response.text();
-	const items = data.split("\n");
-	for (const item of items) {
-		const hashSuffix = item.slice(0, 35).toLowerCase();
-		if (hash === hashPrefix + hashSuffix) {
-			return false;
+
+	try {
+		const response = await fetch(`https://api.pwnedpasswords.com/range/${hashPrefix}`);
+		if (!response.ok) {
+			return true;
 		}
+		const data = await response.text();
+		const items = data.split("\n");
+		for (const item of items) {
+			const hashSuffix = item.slice(0, 35).toLowerCase();
+			if (hash === hashPrefix + hashSuffix) {
+				return false;
+			}
+		}
+	} catch {
+		// Fail open: treat API unavailability as the password being acceptable
+		return true;
 	}
+
 	return true;
 }


### PR DESCRIPTION
## Summary

`verifyPasswordStrength` called the HaveIBeenPwned API without any error handling. A network timeout or non-200 response would throw an unhandled exception and crash the auth flow.

- Wraps the `fetch` call in `try/catch`
- Checks `response.ok` before reading the body
- Fails open in both cases: API unavailability does not block the user

## Test plan

- [ ] Normal registration flow still works
- [ ] Simulating a network failure (e.g. disabling internet) allows registration to proceed rather than throwing a 500

Closes #7