### PR TITLE
Remove unused imports, debug console.log calls and fix boolean type

### DIFF
--- a/src/lib/components/LogForm.svelte
+++ b/src/lib/components/LogForm.svelte
@@ -22,11 +22,7 @@
 		tags: { id: string; label: string }[];
 	}>();
 
-	console.log('InitialData: ', initialData);
-
-	const currentTimestamp = new Date();
-	console.log('Current time: ', currentTimestamp);
-	const currentDateTime = currentTimestamp;
+	const currentDateTime = new Date();
 
 	let note = $state(initialData.note ?? '');
 	let description = $state(initialData.description ?? '');

--- a/src/lib/components/LogTypeForm.svelte
+++ b/src/lib/components/LogTypeForm.svelte
@@ -20,7 +20,6 @@
 	let color = $state(initialData.color ?? '');
 
 	$effect(() => {
-		console.log('Chosen icon:', selectedIcon);
 		icon = selectedIcon;
 		color = selectedColor;
 	});

--- a/src/lib/components/TagForm.svelte
+++ b/src/lib/components/TagForm.svelte
@@ -10,14 +10,12 @@
 	} = $props<{
 		initialData?: Partial<{ id: string; label: string }>;
 		action?: 'create' | 'update';
-		tagInUse: true | false;
+		tagInUse: boolean;
 		tagId: string;
 		count: number;
 	}>();
 
-	$effect(() => {
-		console.log(tagInUse);
-	});
+
 	let label = $state(initialData.label ?? '');
 </script>
 

--- a/src/lib/server/db/schema/log_tag.ts
+++ b/src/lib/server/db/schema/log_tag.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, varchar, uuid } from 'drizzle-orm/pg-core';
+import { pgTable, uuid } from 'drizzle-orm/pg-core';
 import {logEntries } from './log_entries';
 import {tags } from './tags';
 


### PR DESCRIPTION
## Summary

- `log_tag.ts`: remove unused `text` and `varchar` imports
- `LogForm.svelte`: remove two debug `console.log` calls
- `LogTypeForm.svelte`: remove debug `console.log` from `$effect`
- `TagForm.svelte`: remove debug `console.log` from `$effect`, change `true | false` prop type to `boolean`

Closes #8